### PR TITLE
Fix GitHub Actions bundle platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,12 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.30.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -65,6 +69,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.86.3-arm64-darwin)
       google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-x86_64-linux-gnu)
+      google-protobuf (~> 4.30)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -72,6 +78,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.4)


### PR DESCRIPTION
## Summary
- Add the Linux platform to `Gemfile.lock` so `ruby/setup-ruby` can run `bundle install` on GitHub Actions runners.

## Context
The `Deploy Jekyll site to GitHub Pages` workflow failed because the lockfile only supported `arm64-darwin`:

```text
Your bundle only supports platforms [\"arm64-darwin\"] but your local platform is x86_64-linux.
```

## Verification
- `bundle exec jekyll build`